### PR TITLE
debounceTo can not remove `internalTrigger`

### DIFF
--- a/ng-jsoneditor.js
+++ b/ng-jsoneditor.js
@@ -30,7 +30,6 @@
                                 if (editor) {
                                     internalTrigger = true;
                                     ngModel.$setViewValue($scope.preferText === true ? editor.getText() : editor.get());
-                                    internalTrigger = false;
 
                                     if (settings && settings.hasOwnProperty('change')) {
                                         settings.change();
@@ -76,7 +75,11 @@
                 });
 
                 $scope.updateJsonEditor = function (newValue) {
-                    if (internalTrigger) return; //ignore if called by $setViewValue
+                    if (internalTrigger) {
+                        //ignore if called by $setViewValue (after debounceTo)
+                        internalTrigger = false;
+                        return;
+                    }
 
                     if (typeof debounceFrom !== 'undefined') {
                         $timeout.cancel(debounceFrom);


### PR DESCRIPTION
debounceTo is "defered" so if it sets `internalTrigger=false` then debounceFrom always sees it as false...  instead, now, debounceTo sets `internalTrigger=true` and it is not set as `false` until debounceFrom.

-----

The problem I was having, before this, was that I could only type in 1 character, and it would `get-->set` and remove my cursor... now it is behaving correctly.