### PR TITLE
Fix a jsoneditor object recreation when there a "modes" or "ace" option

### DIFF
--- a/ng-jsoneditor.js
+++ b/ng-jsoneditor.js
@@ -65,6 +65,10 @@
                                     editor.setMode(v);
                                 } else if (k === 'name') {
                                     editor.setName(v);
+                                } else if (k === 'ace') {
+                                    // "ace" object cannot be compared, sorry
+                                } else if (k === 'modes' && angular.toJson(newValue[k]) === angular.toJson(oldValue[k])) {
+                                    // "modes" has not been changed
                                 } else { //other settings cannot be changed without re-creating the JsonEditor
                                     editor = _createEditor(newValue);
                                     $scope.updateJsonEditor();


### PR DESCRIPTION
There is a === check, which always fails for arrays and objects. When you specify "modes" (array) or "ace" (object) option, this will cause to almost always recreating jsoneditor object.
In my case, it lead to empty object showing after mode switching via jsoneditor interface.